### PR TITLE
Polish UI: blurred transparent navbar, footer/auth centering, exact posters & optional trailers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask==3.0.3
 pandas==2.2.2
 numpy==1.26.4
 scikit-learn==1.4.2
+

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,30 +1,30 @@
 :root {
-  --nf-black: #141414;
-  --nf-card: #1f1f1f;
+  --nf-black: #0b0c10;
+  --nf-card: #171a22;
   --nf-red: #e50914;
   --nf-text: #e5e5e5;
-
   --nf-accent: #b15cff;
-  --nf-blue: #3c8dff;
 }
 
 body {
-  background: radial-gradient(circle at top right, #1f1b24 0%, #141414 45%);
+  background: radial-gradient(circle at top right, #1d2130 0%, #090a0f 50%);
   color: var(--nf-text);
   font-family: Arial, Helvetica, sans-serif;
-  transition: opacity .28s ease, transform .28s ease;
+  transition: opacity .25s ease, transform .25s ease;
 }
 
-body.page-leave { opacity: .15; transform: translateY(8px) scale(.99); }
-.page-stage { animation: pageEnter .5s ease; }
-@keyframes pageEnter { from { opacity: 0; transform: translateY(14px);} to {opacity:1; transform: translateY(0);} }
+body.page-leave { opacity: .25; transform: translateY(6px); }
+.page-stage { animation: pageEnter .45s ease; min-height: 78vh; }
+@keyframes pageEnter { from { opacity: 0; transform: translateY(12px);} to {opacity:1; transform: translateY(0);} }
 
 .netflix-navbar {
-  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.9), rgba(0, 0, 0, 0.2));
+  background: rgba(9, 10, 15, 0.78);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
   position: sticky;
   top: 0;
   z-index: 1000;
-  border-bottom: 1px solid rgba(255, 255, 255, .08);
+  border-bottom: 1px solid rgba(255, 255, 255, .12);
 }
 
 .netflix-link {
@@ -39,7 +39,7 @@ body.page-leave { opacity: .15; transform: translateY(8px) scale(.99); }
 .netflix-link:hover {
   color: #fff;
   background: linear-gradient(120deg, var(--nf-red), var(--nf-accent));
-  box-shadow: 0 8px 18px rgba(229, 9, 20, 0.35);
+  box-shadow: 0 8px 18px rgba(229, 9, 20, .35);
 }
 
 .netflix-btn {
@@ -47,33 +47,32 @@ body.page-leave { opacity: .15; transform: translateY(8px) scale(.99); }
   color: #fff;
   border: none;
   font-weight: 700;
-  transition: transform .22s ease, box-shadow .22s ease;
 }
 
-.netflix-btn:hover { transform: translateY(-1px); box-shadow: 0 10px 16px rgba(229, 9, 20, .35); color: #fff; }
-.netflix-btn.btn-outline { background: transparent; border: 1px solid #fff; }
+.netflix-btn:hover { color: #fff; transform: translateY(-1px); }
+.netflix-btn.btn-outline { background: transparent; border: 1px solid rgba(255,255,255,.5); }
 
 .auth-screen {
   min-height: 100vh;
-  background-image: linear-gradient(rgba(0,0,0,.6), rgba(0,0,0,.8)), url('/static/images/hero-bg.jpg');
+  background-image: linear-gradient(rgba(0,0,0,.6), rgba(0,0,0,.82)), url('/static/images/hero-bg.jpg');
   background-size: cover;
   background-position: center;
   display: flex;
   align-items: center;
+  position: relative;
 }
 
-.auth-content { text-align: center; }
-.auth-logo { color: var(--nf-red); font-size: 4rem; font-weight: 900; text-shadow: 0 0 20px rgba(229,9,20,.45); }
-.auth-tagline { font-size: 1.2rem; margin-bottom: 2rem; }
+.auth-overlay { position: absolute; inset: 0; background: radial-gradient(circle at top, rgba(181,92,255,.18), transparent 55%); }
+.auth-content { text-align: center; z-index: 1; }
+.auth-logo { color: var(--nf-red); font-size: 4rem; font-weight: 900; text-shadow: 0 0 20px rgba(229,9,20,.4); }
+.auth-tagline { font-size: 1.1rem; margin-bottom: 1.7rem; }
 .auth-actions { display: flex; justify-content: center; gap: 1rem; }
-.auth-actions-hidden { display: none; }
 .auth-enter { animation: authEnter .6s ease; }
-.auth-leave { animation: authLeave .35s ease forwards; }
+.auth-leave { animation: authLeave .3s ease forwards; }
 @keyframes authEnter { from { opacity: 0; transform: scale(.94) translateY(10px);} to {opacity:1; transform: scale(1) translateY(0);} }
 @keyframes authLeave { to { opacity:0; transform: translateY(-10px) scale(.96);} }
 
-.auth-form-wrap { display: none; justify-content: center; }
-.auth-form-wrap.show { display: flex; }
+.auth-form-wrap { display: flex; justify-content: center; }
 .auth-form-card {
   width: min(430px, 92vw);
   text-align: left;
@@ -82,150 +81,35 @@ body.page-leave { opacity: .15; transform: translateY(8px) scale(.99); }
   border: 1px solid rgba(255,255,255,.2);
   border-radius: 12px;
   padding: 2rem;
-  box-shadow: 0 20px 30px rgba(0,0,0,.3);
 }
+.auth-form-title { text-align: center; margin-bottom: 1.2rem; }
 
 .netflix-input { background: rgba(20,20,20,.85); border: 1px solid #555; color: #fff; }
 .netflix-input:focus { border-color: var(--nf-red); box-shadow: 0 0 0 .2rem rgba(229,9,20,.22); background: rgba(20,20,20,.95); color: #fff; }
 
 .netflix-hero {
   padding: 6rem 0;
-  background-image: linear-gradient(to right, rgba(0,0,0,.92), rgba(0,0,0,.35)), url('https://images.unsplash.com/photo-1440404653325-ab127d49abc1?auto=format&fit=crop&w=1600&q=80');
+  background-image: linear-gradient(to right, rgba(0,0,0,.9), rgba(0,0,0,.4)), url('https://images.unsplash.com/photo-1440404653325-ab127d49abc1?auto=format&fit=crop&w=1600&q=80');
   background-size: cover;
 }
 
-.row-title { font-weight: 800; margin-bottom: 1rem; letter-spacing: .4px; }
-
-.nf-stat {
-  background: #202020;
-  border-left: 4px solid var(--nf-red);
-  border-radius: 8px;
-  padding: 1rem;
-  transition: transform .2s ease;
-
-}
-
-body {
-  background: var(--nf-black);
-  color: var(--nf-text);
-  font-family: Arial, Helvetica, sans-serif;
-}
-
-.netflix-navbar {
-  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.85), rgba(0, 0, 0, 0.15));
-  position: sticky;
-  top: 0;
-  z-index: 1000;
-}
-
-.netflix-link {
-  color: #fff;
-  font-weight: 600;
-}
-
-.netflix-link.active,
-.netflix-link:hover { color: var(--nf-red); }
-
-.netflix-btn {
-  background: var(--nf-red);
-  color: #fff;
-  border: none;
-  font-weight: 700;
-}
-
-.netflix-btn:hover { background: #b30710; color: #fff; }
-.netflix-btn.btn-outline { background: transparent; border: 1px solid #fff; }
-
-.auth-screen {
-  min-height: 100vh;
-  position: relative;
-  background-image: linear-gradient(rgba(0,0,0,.65), rgba(0,0,0,.8)), url('/static/images/hero-bg.jpg');
-  background-size: cover;
-  background-position: center;
-  display: flex;
-  align-items: center;
-}
-
-.auth-content { position: relative; z-index: 2; text-align: center; }
-.auth-logo { color: var(--nf-red); font-size: 4rem; font-weight: 900; }
-.auth-tagline { font-size: 1.2rem; margin-bottom: 2rem; }
-.auth-actions { display: flex; justify-content: center; gap: 1rem; }
-.auth-actions-hidden { display: none; }
-
-.auth-form-wrap { display: none; justify-content: center; }
-.auth-form-wrap.show { display: flex; }
-.auth-form-card {
-  width: min(430px, 92vw);
-  text-align: left;
-  background: rgba(17, 17, 17, 0.72);
-  backdrop-filter: blur(8px);
-  border: 1px solid rgba(255,255,255,.2);
-  border-radius: 12px;
-  padding: 2rem;
-}
-
-.netflix-input { background: rgba(20,20,20,.85); border: 1px solid #555; color: #fff; }
-
-.netflix-hero {
-  padding: 6rem 0;
-  background-image: linear-gradient(to right, rgba(0,0,0,.92), rgba(0,0,0,.35)), url('https://images.unsplash.com/photo-1440404653325-ab127d49abc1?auto=format&fit=crop&w=1600&q=80');
-  background-size: cover;
-}
-
-.row-title { font-weight: 800; margin-bottom: 1rem; }
-
-.nf-stat {
-  background: #202020;
-  border-left: 4px solid var(--nf-red);
-  border-radius: 8px;
-  padding: 1rem;
-}
-
-.nf-stat span { display: block; color: #aaa; }
+.row-title { font-weight: 800; margin-bottom: 1rem; letter-spacing: .3px; }
+.nf-stat { background: #202534; border-left: 4px solid var(--nf-red); border-radius: 10px; padding: 1rem; }
+.nf-stat span { display: block; color: #adb5bd; }
 .nf-stat strong { font-size: 1.4rem; }
 
-.movie-row, .movie-grid {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
-
-}
-.nf-stat:hover { transform: translateY(-4px); }
-
-.nf-stat span { display: block; color: #aaa; }
-.nf-stat strong { font-size: 1.4rem; }
-
-
-.movie-row, .movie-grid {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
-
-.movie-card {
-  background: var(--nf-card);
-  border-radius: 10px;
-  overflow: hidden;
-  transition: transform .2s ease;
-
-}
-.movie-card:hover { transform: scale(1.03); }
-
-
-.movie-card {
-  background: var(--nf-card);
-  border-radius: 10px;
-  overflow: hidden;
-  transition: transform .2s ease, box-shadow .2s ease;
-}
-.movie-card:hover { transform: scale(1.03); box-shadow: 0 12px 18px rgba(0,0,0,.35); }
-
-.movie-poster { width: 100%; height: 300px; object-fit: cover; }
+.movie-row, .movie-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(210px, 1fr)); }
+.movie-card { background: var(--nf-card); border-radius: 12px; overflow: hidden; transition: transform .2s ease, box-shadow .2s ease; }
+.movie-card:hover { transform: translateY(-2px); box-shadow: 0 12px 18px rgba(0,0,0,.35); }
+.movie-poster { width: 100%; height: 300px; object-fit: cover; background: #111; }
 .movie-info { padding: .8rem; }
-.movie-info h5 { font-size: 1rem; margin-bottom: .4rem; }
-.movie-info p { color: #b9b9b9; font-size: .85rem; }
+.movie-info p { color: #b9b9b9; }
 
-.netflix-modal { background: #181818; color: #fff; border: 1px solid rgba(255,255,255,.12); }
-.score-chip { color: #fff !important; background: linear-gradient(120deg, #303030, #3c3c3c); display: inline-block; padding: .2rem .5rem; border-radius: 999px; }
+.netflix-modal { background: #131722; color: #fff; border: 1px solid rgba(255,255,255,.12); }
+.score-chip { color: #fff; background: #2f3443; display: inline-block; padding: .2rem .5rem; border-radius: 999px; }
+
+.trailer-wrap h6 { text-align: center; margin-bottom: .7rem; color: #eecfff; }
+.trailer-frame { overflow: hidden; border-radius: 12px; border: 1px solid rgba(255,255,255,.12); box-shadow: 0 10px 20px rgba(0,0,0,.35); }
 
 .rating-stars { display: inline-flex; flex-direction: row-reverse; gap: .15rem; }
 .rating-stars input { display: none; }
@@ -240,15 +124,15 @@ body {
   border: 1px solid rgba(255,255,255,.12);
   border-radius: 14px;
   padding: 1.25rem;
-  box-shadow: 0 10px 20px rgba(0,0,0,.3);
 }
 
 .site-footer {
   border-top: 1px solid rgba(255,255,255,.12);
-  background: linear-gradient(to bottom, rgba(0,0,0,.25), rgba(0,0,0,.7));
+  background: linear-gradient(to bottom, rgba(14,16,24,.65), rgba(6,7,12,.95));
 }
-.footer-title { font-weight: 800; }
-.footer-list { list-style: none; padding: 0; margin: 0; }
+.footer-title { font-weight: 800; text-align: center; margin-bottom: .8rem; }
+.footer-text { color: #c7c7c7; }
+.footer-list { list-style: none; padding: 0; margin: 0; text-align: center; }
 .footer-list li { margin-bottom: .45rem; color: #c7c7c7; }
 .footer-list a { color: #fff; text-decoration: none; }
 .footer-list a:hover { color: #ff6a8f; }
@@ -258,7 +142,7 @@ body {
   display: inline-flex;
   align-items: center;
   gap: .5rem;
-  padding: .8rem 1rem;
+  padding: .7rem 1rem;
   border-radius: 999px;
   text-decoration: none;
   color: #fff;
@@ -266,41 +150,14 @@ body {
   border: 1px solid rgba(255,255,255,.12);
   font-weight: 700;
   transition: all .2s ease;
-  
-.movie-poster {
-  width: 100%;
-  height: 300px;
-  object-fit: cover;
 }
-.social-pill i { font-size: 1.35rem; }
 .social-pill:hover { transform: translateY(-3px); border-color: var(--nf-red); box-shadow: 0 8px 16px rgba(229,9,20,.25); color: #fff; }
 
+@media (min-width: 768px) {
+  .footer-title, .footer-list { text-align: left; }
+}
 
 @media (max-width: 576px) {
   .auth-logo { font-size: 2.7rem; }
   .star-action-row { justify-content: center; }
-
-.movie-info { padding: .8rem; }
-.movie-info h5 { font-size: 1rem; margin-bottom: .4rem; }
-.movie-info p { color: #b9b9b9; font-size: .85rem; }
-
-.netflix-modal { background: #181818; color: #fff; }
-.score-chip { color: #fff !important; background: #303030; display: inline-block; padding: .2rem .5rem; border-radius: 999px; }
-
-.rating-stars {
-  display: inline-flex;
-  flex-direction: row-reverse;
-  gap: .15rem;
-}
-
-.rating-stars input { display: none; }
-.rating-stars label {
-  font-size: 1.4rem;
-  color: #666;
-  cursor: pointer;
-}
-.rating-stars input:checked ~ label,
-.rating-stars label:hover,
-.rating-stars label:hover ~ label {
-  color: #ffd54a;
 }

--- a/templates/auth.html
+++ b/templates/auth.html
@@ -1,28 +1,22 @@
 {% extends 'base.html' %}
 {% block content %}
 <section class="auth-screen">
-
-  <div class="auth-content container auth-enter">
-
   <div class="auth-overlay"></div>
-  <div class="auth-content container">
-
+  <div class="auth-content container {% if not auth_mode %}auth-enter{% endif %}">
     <h1 class="auth-logo">SmartRecs</h1>
     <p class="auth-tagline">Your next favorite movie is one click away.</p>
 
-    <div class="auth-actions {% if auth_mode %}auth-actions-hidden{% endif %}">
-
+    {% if not auth_mode %}
+    <div class="auth-actions">
       <button class="btn netflix-btn auth-shift" data-open-auth="login">Login</button>
       <button class="btn netflix-btn btn-outline auth-shift" data-open-auth="register">Register</button>
-
-      <button class="btn netflix-btn" data-open-auth="login">Login</button>
-      <button class="btn netflix-btn btn-outline" data-open-auth="register">Register</button>
-
     </div>
+    {% endif %}
 
-    <div class="auth-form-wrap {% if auth_mode %}show{% endif %}" id="authFormWrap">
+    {% if auth_mode %}
+    <div class="auth-form-wrap show" id="authFormWrap">
       <div class="auth-form-card">
-        <h2 id="authFormTitle">{{ 'Create Account' if auth_mode == 'register' else 'Sign In' }}</h2>
+        <h2 class="auth-form-title">{{ 'Register' if auth_mode == 'register' else 'Sign In' }}</h2>
         {% if auth_mode == 'register' %}
         <form method="post" action="{{ url_for('register') }}">
           <div class="mb-3">
@@ -30,13 +24,10 @@
             <input name="username" class="form-control netflix-input" required>
           </div>
           <div class="mb-3">
-
             <label class="form-label">Email</label>
             <input type="email" name="email" class="form-control netflix-input" placeholder="name@email.com">
           </div>
           <div class="mb-3">
-
-
             <label class="form-label">Password</label>
             <input type="password" name="password" class="form-control netflix-input" required>
           </div>
@@ -57,6 +48,7 @@
         {% endif %}
       </div>
     </div>
+    {% endif %}
   </div>
 </section>
 
@@ -64,14 +56,10 @@
   document.querySelectorAll('[data-open-auth]').forEach((button) => {
     button.addEventListener('click', () => {
       const mode = button.getAttribute('data-open-auth');
-
       document.querySelector('.auth-content')?.classList.add('auth-leave');
       setTimeout(() => {
         window.location.href = mode === 'login' ? '{{ url_for('login') }}?mode=login' : '{{ url_for('register') }}?mode=register';
-      }, 300);
-
-      window.location.href = mode === 'login' ? '{{ url_for('login') }}?mode=login' : '{{ url_for('register') }}?mode=register';
-
+      }, 280);
     });
   });
 </script>

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>SmartRecs</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
   <link href="{{ url_for('static', filename='css/style.css') }}" rel="stylesheet">
 </head>
 <body>
@@ -12,35 +13,23 @@
   <nav class="navbar navbar-expand-lg netflix-navbar">
     <div class="container">
       <a class="navbar-brand text-danger fw-bold fs-3" href="{{ url_for('dashboard') }}">SMARTRECS</a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="collapse navbar-collapse" id="navbarNav">
-
         <ul class="navbar-nav ms-auto gap-lg-2">
           <li class="nav-item"><a class="nav-link netflix-link page-shift {% if active_tab == 'dashboard' %}active{% endif %}" href="{{ url_for('dashboard') }}">Home</a></li>
           <li class="nav-item"><a class="nav-link netflix-link page-shift {% if active_tab == 'rate' %}active{% endif %}" href="{{ url_for('rate_movies') }}">Rate</a></li>
           <li class="nav-item"><a class="nav-link netflix-link page-shift {% if active_tab == 'recommendations' %}active{% endif %}" href="{{ url_for('recommendations') }}">My List</a></li>
           <li class="nav-item"><a class="nav-link netflix-link page-shift {% if active_tab == 'profile' %}active{% endif %}" href="{{ url_for('profile') }}">Profile</a></li>
           <li class="nav-item"><a class="nav-link netflix-link page-shift" href="{{ url_for('logout') }}">Logout</a></li>
-
-        <ul class="navbar-nav ms-auto gap-lg-4">
-          <li class="nav-item"><a class="nav-link netflix-link {% if active_tab == 'dashboard' %}active{% endif %}" href="{{ url_for('dashboard') }}">Home</a></li>
-          <li class="nav-item"><a class="nav-link netflix-link {% if active_tab == 'rate' %}active{% endif %}" href="{{ url_for('rate_movies') }}">Rate</a></li>
-          <li class="nav-item"><a class="nav-link netflix-link {% if active_tab == 'recommendations' %}active{% endif %}" href="{{ url_for('recommendations') }}">My List</a></li>
-          <li class="nav-item"><a class="nav-link netflix-link" href="{{ url_for('logout') }}">Logout</a></li>
-
         </ul>
       </div>
     </div>
   </nav>
   {% endif %}
 
-
   <main class="page-stage">
-
-  <main>
-
     <div class="container mt-3 flash-wrap">
       {% with messages = get_flashed_messages(with_categories=true) %}
         {% for category, message in messages %}
@@ -54,11 +43,11 @@
   {% if not auth_page %}
   {% block footer %}
   <footer class="site-footer mt-5">
-    <div class="container py-4">
-      <div class="row g-4">
+    <div class="container py-5">
+      <div class="row g-4 text-center text-md-start align-items-start">
         <div class="col-md-4">
           <h5 class="footer-title">SmartRecs</h5>
-          <p>Discover movies, track your taste profile, and get tailored recommendations in seconds.</p>
+          <p class="footer-text">Discover movies, track your taste profile, and get tailored recommendations in seconds.</p>
         </div>
         <div class="col-md-4">
           <h6 class="footer-title">Explore</h6>
@@ -90,7 +79,7 @@
         if (!href || href.startsWith('#')) return;
         event.preventDefault();
         document.body.classList.add('page-leave');
-        setTimeout(() => { window.location.href = href; }, 280);
+        setTimeout(() => { window.location.href = href; }, 220);
       });
     });
   </script>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -4,11 +4,7 @@
   <div class="container">
     <h1>Welcome back, {{ session.get('username', 'Viewer')|title }}</h1>
     <p>Your movie night dashboard with AI-personalized picks.</p>
-
     <a href="{{ url_for('rate_movies') }}" class="btn netflix-btn page-shift">Rate Movies</a>
-
-    <a href="{{ url_for('rate_movies') }}" class="btn netflix-btn">Rate Movies</a>
-
   </div>
 </section>
 
@@ -34,18 +30,24 @@
     </article>
 
     <div class="modal fade" id="movieModal{{ movie.movie_id }}" tabindex="-1" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-dialog modal-lg modal-dialog-centered">
         <div class="modal-content netflix-modal">
           <div class="modal-header border-0">
             <h5 class="modal-title">{{ movie.clean_title }} ({{ movie.year }})</h5>
             <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
           </div>
           <div class="modal-body">
-
             <p><strong>Release date:</strong> {{ movie.release_date }}</p>
-
             <p>{{ movie.description }}</p>
             <p class="text-danger fw-bold">AI Score: {{ '%.2f'|format(movie.score) }}</p>
+            {% if movie.trailer_embed_url %}
+            <div class="trailer-wrap mt-3">
+              <h6>Watch Trailer</h6>
+              <div class="ratio ratio-16x9 trailer-frame">
+                <iframe src="{{ movie.trailer_embed_url }}" title="{{ movie.clean_title }} trailer" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+              </div>
+            </div>
+            {% endif %}
           </div>
         </div>
       </div>
@@ -53,14 +55,13 @@
     {% endfor %}
   </div>
 </section>
-
 {% endblock %}
 
 {% block footer %}
 <footer class="site-footer dashboard-footer mt-5">
-  <div class="container py-4">
-    <h4 class="footer-title mb-3">Let’s Connect</h4>
-    <div class="social-icon-row">
+  <div class="container py-5">
+    <h4 class="footer-title text-center mb-4">Let’s Connect</h4>
+    <div class="social-icon-row justify-content-center">
       <a href="https://github.com/skumalo0115-commits" target="_blank" class="social-pill" aria-label="GitHub"><i class="bi bi-github"></i><span>GitHub</span></a>
       <a href="https://sbahle-kumalo-emerging-technologies.base44.app/" target="_blank" class="social-pill" aria-label="Portfolio"><i class="bi bi-globe2"></i><span>Portfolio</span></a>
       <a href="https://www.facebook.com/share/1DL66XnWr5/?mibextid=wwXIfr" target="_blank" class="social-pill" aria-label="Facebook"><i class="bi bi-facebook"></i><span>Facebook</span></a>
@@ -69,5 +70,4 @@
     </div>
   </div>
 </footer>
-
 {% endblock %}

--- a/templates/rate.html
+++ b/templates/rate.html
@@ -13,7 +13,6 @@
 
         <form method="post" class="star-form mt-3">
           <input type="hidden" name="movie_id" value="{{ movie.movie_id }}">
-
           <div class="star-action-row">
             <div class="rating-stars">
               {% for value in [5,4,3,2,1] %}
@@ -23,33 +22,29 @@
             </div>
             <button class="btn btn-sm netflix-btn">Save Rating</button>
           </div>
-
-          <div class="rating-stars">
-            {% for value in [5,4,3,2,1] %}
-            <input type="radio" id="star{{ movie.movie_id }}-{{ value }}" name="rating" value="{{ value }}" required>
-            <label for="star{{ movie.movie_id }}-{{ value }}">★</label>
-            {% endfor %}
-          </div>
-          <button class="btn btn-sm netflix-btn mt-2">Save Rating</button>
         </form>
       </div>
     </article>
 
     <div class="modal fade" id="movieModal{{ movie.movie_id }}" tabindex="-1" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-dialog modal-lg modal-dialog-centered">
         <div class="modal-content netflix-modal">
           <div class="modal-header border-0">
             <h5 class="modal-title">{{ movie.clean_title }} ({{ movie.year }})</h5>
             <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
           </div>
-
           <div class="modal-body">
             <p><strong>Release date:</strong> {{ movie.release_date }}</p>
             <p>{{ movie.description }}</p>
+            {% if movie.trailer_embed_url %}
+            <div class="trailer-wrap mt-3">
+              <h6>Watch Trailer</h6>
+              <div class="ratio ratio-16x9 trailer-frame">
+                <iframe src="{{ movie.trailer_embed_url }}" title="{{ movie.clean_title }} trailer" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+              </div>
+            </div>
+            {% endif %}
           </div>
-
-          <div class="modal-body"><p>{{ movie.description }}</p></div>
-
         </div>
       </div>
     </div>

--- a/templates/recommendations.html
+++ b/templates/recommendations.html
@@ -15,20 +15,24 @@
     </article>
 
     <div class="modal fade" id="movieModal{{ movie.movie_id }}" tabindex="-1" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-dialog modal-lg modal-dialog-centered">
         <div class="modal-content netflix-modal">
           <div class="modal-header border-0">
             <h5 class="modal-title">{{ movie.clean_title }} ({{ movie.year }})</h5>
             <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
           </div>
-          
           <div class="modal-body">
             <p><strong>Release date:</strong> {{ movie.release_date }}</p>
             <p>{{ movie.description }}</p>
+            {% if movie.trailer_embed_url %}
+            <div class="trailer-wrap mt-3">
+              <h6>Watch Trailer</h6>
+              <div class="ratio ratio-16x9 trailer-frame">
+                <iframe src="{{ movie.trailer_embed_url }}" title="{{ movie.clean_title }} trailer" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+              </div>
+            </div>
+            {% endif %}
           </div>
-
-          <div class="modal-body"><p>{{ movie.description }}</p></div>
-
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Make the site visually consistent: transparent (blurred) navbars, a proper-looking footer, centered auth headings, and polished movie cards as requested. 
- Remove duplicated template and CSS fragments that caused repeated nav links and layout issues. 
- Show exact movie covers where possible and add an embedded trailer area in the movie detail modal for a nicer user experience.

### Description
- Consolidated layout and removed duplicate nav/main fragments by rebuilding `templates/base.html` and cleaning `templates/auth.html`, `templates/dashboard.html`, `templates/recommendations.html`, and `templates/rate.html` so navigation and footer render once and headings are centred. 
- Reworked styling in `static/css/style.css` to provide a blurred semi-transparent sticky navbar, improved footer visuals, centralised auth titles, refined movie cards, and themed trailer frame styling. 
- Backend: consolidated duplicate `movie_with_details` logic into one implementation in `app.py`, added a larger curated `POSTER_MAP`, introduced `TRAILER_MAP` and optional `trailer_embed_url` for modals, and added an optional TMDB search (`TMDB_API_KEY`) using `urllib` as a fallback for better poster matching. 
- Removed duplicated form/modal markup, removed the reliance on the external `requests` package by switching to stdlib HTTP, updated `requirements.txt`, and added deterministic fallbacks for posters and trailers.

### Testing
- Ran Python bytecode check with `python -m compileall app.py` which completed successfully. 
- Verified the running app and route map with `python - <<'PY' from app import app; print('routes', len(app.url_map._rules)) PY` which returned a smoke-check (9 routes) successfully. 
- Performed an automated end-to-end browser flow (register → login → open recommendations) and captured a Playwright screenshot artifact (`artifacts/recommendations_updated.png`) for visual verification. 
- Attempted `pip install -r requirements.txt` for `requests` initially failed due to network/proxy resolution, the code was updated to remove the `requests` dependency and use stdlib networking instead and the app was re-validated afterwards successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a52fac0f483319c4bee70bd13df18)