### PR TITLE
Add popcorn branding, auth motion effects, profile styling, and universal trailer fallback

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ import os
 import re
 from collections import Counter
 from functools import lru_cache
-from urllib.parse import urlencode
+from urllib.parse import quote_plus, urlencode
 from urllib.request import urlopen
 
 import os
@@ -16,7 +16,7 @@ from collections import Counter
 
 import pandas as pd
 import json
-from urllib.parse import urlencode
+from urllib.parse import quote_plus, urlencode
 from urllib.request import urlopen
 from flask import Flask, flash, redirect, render_template, request, session, url_for
 from werkzeug.security import check_password_hash, generate_password_hash
@@ -49,6 +49,26 @@ POSTER_MAP = {
     "whiplash": "https://image.tmdb.org/t/p/w500/7fn624j5lj3xTme2SgiLCeuedmO.jpg",
     "the social network": "https://image.tmdb.org/t/p/w500/n0ybibhJtQ5icDqTp8eRytcIHJx.jpg",
     "the lord of the rings: the fellowship of the ring": "https://image.tmdb.org/t/p/w500/6oom5QYQ2yQTMJIbnvbkBL9cHo6.jpg",
+    "the grand budapest hotel": "https://image.tmdb.org/t/p/w500/eWdyYQreja6JGCzqHWXpWHDrrPo.jpg",
+    "her": "https://image.tmdb.org/t/p/w500/eCOtqtfvn7mxGl6nfmq4b1exJRc.jpg",
+    "la la land": "https://image.tmdb.org/t/p/w500/uDO8zWDhfWwoFdKS4fzkUJt0Rf0.jpg",
+    "the lion king": "https://image.tmdb.org/t/p/w500/2bXbqYdUdNVa8VIWXVfclP2ICtT.jpg",
+    "gladiator": "https://image.tmdb.org/t/p/w500/ty8TGRuvJLPUmAR1H1nRIsgwvim.jpg",
+    "the silence of the lambs": "https://image.tmdb.org/t/p/w500/uS9m8OBk1A8eM9I042bx8XXpqAq.jpg",
+    "toy story": "https://image.tmdb.org/t/p/w500/uXDfjJbdP4ijW5hWSBrPrlKpxab.jpg",
+    "se7en": "https://image.tmdb.org/t/p/w500/6yoghtyTpznpBik8EngEmJskVUO.jpg",
+    "the truman show": "https://image.tmdb.org/t/p/w500/vuza0WqY239yBXOadKlGwJsZJFE.jpg",
+    "the departed": "https://image.tmdb.org/t/p/w500/nT97ifVT2J1yMQmeq20Qblg61T.jpg",
+    "black panther": "https://image.tmdb.org/t/p/w500/uxzzxijgPIY7slzFvMotPv8wjKA.jpg",
+    "coco": "https://image.tmdb.org/t/p/w500/gGEsBPAijhVUFoiNpgZXqRVWJt2.jpg",
+    "ford v ferrari": "https://image.tmdb.org/t/p/w500/dR1Ju50iudrOh3YgfwkAU1g2HZe.jpg",
+    "knives out": "https://image.tmdb.org/t/p/w500/pThyQovXQrw2m0s9x82twj48Jq4.jpg",
+    "the martian": "https://image.tmdb.org/t/p/w500/5aGhaIHYuQbqlHWvWYqMCnj40y2.jpg",
+    "no country for old men": "https://image.tmdb.org/t/p/w500/6d5XOczc226jECq0LIX0siKtgHR.jpg",
+    "the imitation game": "https://image.tmdb.org/t/p/w500/zSqJ1qFq8NXFfi7JeIYMlzyR0dx.jpg",
+    "inside out": "https://image.tmdb.org/t/p/w500/2H1TmgdfNtsKlU9jKdeNyYL5y8T.jpg",
+    "a quiet place": "https://image.tmdb.org/t/p/w500/nAU74GmpUk7t5iklEp3bufwDq4n.jpg",
+    "everything everywhere all at once": "https://image.tmdb.org/t/p/w500/w3LxiVYdWWRvEVdn5RYq6jIqkb1.jpg",
 }
 
 
@@ -209,16 +229,20 @@ def movie_with_details(movie: dict) -> dict:
     )
 
     trailer_id = TRAILER_MAP.get(lower_title)
-
+    fallback_query = quote_plus(f"{clean_title} official trailer")
 
     movie_copy["clean_title"] = clean_title
     movie_copy["year"] = resolved_year
     movie_copy["release_date"] = release_date
     movie_copy["description"] = description
     movie_copy["pretty_genres"] = pretty_genres
-    movie_copy["poster_url"] = poster_url
+    movie_copy["poster_url"] = poster_url or f"https://picsum.photos/seed/smartrecs-{movie_id}/480/720"
 
-    movie_copy["trailer_embed_url"] = f"https://www.youtube.com/embed/{trailer_id}" if trailer_id else None
+    movie_copy["trailer_embed_url"] = (
+        f"https://www.youtube.com/embed/{trailer_id}"
+        if trailer_id
+        else f"https://www.youtube.com/embed?listType=search&list={fallback_query}"
+    )
     return movie_copy
 
 

--- a/data/movies.csv
+++ b/data/movies.csv
@@ -19,3 +19,23 @@ movie_id,title,genres
 18,Parasite,Comedy|Drama|Thriller
 19,Dune,Adventure|Drama|Sci-Fi
 20,Spider-Man: Into the Spider-Verse,Action|Animation|Adventure
+21,The Grand Budapest Hotel,Adventure|Comedy|Crime
+22,Her,Drama|Romance|Sci-Fi
+23,La La Land,Comedy|Drama|Music
+24,The Lion King,Animation|Adventure|Drama
+25,Gladiator,Action|Adventure|Drama
+26,The Silence of the Lambs,Crime|Drama|Thriller
+27,Toy Story,Animation|Adventure|Comedy
+28,Se7en,Crime|Drama|Mystery
+29,The Truman Show,Comedy|Drama|Sci-Fi
+30,The Departed,Crime|Drama|Thriller
+31,Black Panther,Action|Adventure|Sci-Fi
+32,Coco,Animation|Adventure|Family
+33,Ford v Ferrari,Action|Biography|Drama
+34,Knives Out,Comedy|Crime|Drama
+35,The Martian,Adventure|Drama|Sci-Fi
+36,No Country for Old Men,Crime|Drama|Thriller
+37,The Imitation Game,Biography|Drama|Thriller
+38,Inside Out,Animation|Adventure|Comedy
+39,A Quiet Place,Drama|Horror|Sci-Fi
+40,Everything Everywhere All at Once,Action|Adventure|Comedy

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -171,20 +171,32 @@ body.page-leave { opacity: .25; transform: translateY(6px); }
 }
 
 
-.flash-wrap .alert {
+.flash-toast-wrap {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  z-index: 2000;
+  width: min(420px, calc(100vw - 2rem));
+}
+.flash-toast {
   border: 1px solid rgba(255,255,255,.18);
   border-radius: 12px;
   backdrop-filter: blur(8px);
   box-shadow: 0 10px 22px rgba(0,0,0,.28);
   animation: flashIn .35s ease;
 }
-.flash-wrap .alert-success {
-  background: linear-gradient(120deg, rgba(25,135,84,.85), rgba(34,197,94,.3));
+.flash-toast.alert-success {
+  background: linear-gradient(120deg, rgba(25,135,84,.9), rgba(34,197,94,.35));
   color: #ebfff4;
 }
-.flash-wrap .alert-danger {
-  background: linear-gradient(120deg, rgba(220,53,69,.85), rgba(229,9,20,.25));
+.flash-toast.alert-danger {
+  background: linear-gradient(120deg, rgba(220,53,69,.9), rgba(229,9,20,.3));
   color: #fff1f3;
+}
+.flash-toast-hide {
+  opacity: 0;
+  transform: translateY(-8px);
+  transition: opacity .28s ease, transform .28s ease;
 }
 @keyframes flashIn { from {opacity: 0; transform: translateY(-6px);} to {opacity:1; transform: translateY(0);} }
 
@@ -198,10 +210,98 @@ body.page-leave { opacity: .25; transform: translateY(6px); }
   padding-top: .4rem;
 }
 
+.movie-meta {
+  min-height: 88px;
+}
+.movie-meta h5 {
+  margin-bottom: .35rem;
+}
+
+
 .profile-card-cool {
   max-width: 860px;
   background: linear-gradient(145deg, rgba(24,28,40,.92), rgba(14,17,26,.95));
   border: 1px solid rgba(177,92,255,.25);
   box-shadow: 0 18px 35px rgba(0,0,0,.35), 0 0 0 1px rgba(255,255,255,.04) inset;
 
+}
+
+
+.popcorn-nav {
+  display: inline-block;
+  margin-left: .35rem;
+  animation: popcornWiggle 2.2s ease-in-out infinite;
+}
+
+.auth-logo {
+  animation: beamPulse 2.4s ease-in-out infinite;
+}
+
+.popcorn-pop {
+  display: inline-block;
+  margin-left: .4rem;
+  animation: popcornFloat 1.8s ease-in-out infinite;
+}
+
+.auth-tagline-swoop {
+  animation: taglineSlideIn .7s ease both;
+}
+
+.auth-actions-merge {
+  animation: actionCenterIn .7s ease .15s both;
+}
+
+.auth-btn-left {
+  animation: btnFromLeft .75s ease .2s both;
+}
+
+.auth-btn-right {
+  animation: btnFromRight .75s ease .2s both;
+}
+
+.auth-form-card-enter {
+  animation: formRiseIn .75s ease both;
+}
+
+.optional-note {
+  color: #c7ccd7 !important;
+}
+
+.profile-card .netflix-input::placeholder {
+  color: #b8bec9;
+  opacity: 1;
+}
+
+@keyframes beamPulse {
+  0%, 100% { text-shadow: 0 0 12px rgba(229,9,20,.45), 0 0 24px rgba(177,92,255,.2); }
+  50% { text-shadow: 0 0 18px rgba(255,94,133,.75), 0 0 34px rgba(177,92,255,.5); }
+}
+@keyframes popcornFloat {
+  0%, 100% { transform: translateY(0) rotate(0deg); }
+  50% { transform: translateY(-4px) rotate(-7deg); }
+}
+@keyframes popcornWiggle {
+  0%,100% { transform: rotate(0deg); }
+  25% { transform: rotate(-7deg); }
+  75% { transform: rotate(7deg); }
+}
+@keyframes taglineSlideIn {
+  from { opacity: 0; transform: translateX(-28px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+@keyframes actionCenterIn {
+  from { opacity: 0; transform: scale(.92); }
+  to { opacity: 1; transform: scale(1); }
+}
+@keyframes btnFromLeft {
+  from { opacity: 0; transform: translateX(-42px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+@keyframes btnFromRight {
+  from { opacity: 0; transform: translateX(42px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+@keyframes formRiseIn {
+  from { opacity: 0; transform: translateY(28px) scale(.97); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
 }

--- a/templates/auth.html
+++ b/templates/auth.html
@@ -3,19 +3,19 @@
 <section class="auth-screen">
   <div class="auth-overlay"></div>
   <div class="auth-content container {% if not auth_mode %}auth-enter{% endif %}">
-    <h1 class="auth-logo">SmartRecs</h1>
-    <p class="auth-tagline">Your next favorite movie is one click away.</p>
+    <h1 class="auth-logo">SmartRecs <span class="popcorn-pop" aria-hidden="true">🍿</span></h1>
+    <p class="auth-tagline auth-tagline-swoop">Your next favorite movie is one click away.</p>
 
     {% if not auth_mode %}
-    <div class="auth-actions">
-      <button class="btn netflix-btn auth-shift" data-open-auth="login">Login</button>
-      <button class="btn netflix-btn btn-outline auth-shift" data-open-auth="register">Register</button>
+    <div class="auth-actions auth-actions-merge">
+      <button class="btn netflix-btn auth-shift auth-btn-left" data-open-auth="login">Login</button>
+      <button class="btn netflix-btn btn-outline auth-shift auth-btn-right" data-open-auth="register">Register</button>
     </div>
     {% endif %}
 
     {% if auth_mode %}
     <div class="auth-form-wrap show" id="authFormWrap">
-      <div class="auth-form-card">
+      <div class="auth-form-card auth-form-card-enter">
         <h2 class="auth-form-title">{{ 'Register' if auth_mode == 'register' else 'Sign In' }}</h2>
         {% if auth_mode == 'register' %}
         <form method="post" action="{{ url_for('register') }}">

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,7 +12,7 @@
   {% if session.get('user_id') %}
   <nav class="navbar navbar-expand-lg netflix-navbar">
     <div class="container">
-      <a class="navbar-brand text-danger fw-bold fs-3" href="{{ url_for('dashboard') }}">SMARTRECS</a>
+      <a class="navbar-brand text-danger fw-bold fs-3" href="{{ url_for('dashboard') }}">SMARTRECS <span class="popcorn-nav" aria-hidden="true">🍿</span></a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
@@ -30,10 +30,10 @@
   {% endif %}
 
   <main class="page-stage">
-    <div class="container mt-3 flash-wrap">
+    <div class="flash-toast-wrap" aria-live="polite" aria-atomic="true">
       {% with messages = get_flashed_messages(with_categories=true) %}
         {% for category, message in messages %}
-          <div class="alert alert-{{ category }} mb-2">{{ message }}</div>
+          <div class="alert alert-{{ category }} flash-toast mb-2" role="alert" data-flash-category="{{ category }}">{{ message }}</div>
         {% endfor %}
       {% endwith %}
     </div>
@@ -81,6 +81,13 @@
         document.body.classList.add('page-leave');
         setTimeout(() => { window.location.href = href; }, 220);
       });
+    });
+
+    document.querySelectorAll('.flash-toast[data-flash-category="success"]').forEach((toast) => {
+      setTimeout(() => {
+        toast.classList.add('flash-toast-hide');
+        setTimeout(() => toast.remove(), 280);
+      }, 3000);
     });
   </script>
 </body>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -44,8 +44,6 @@
             <p><strong>Genre:</strong> {{ movie.pretty_genres }}</p>
             <p><strong>Description:</strong> {{ movie.description }}</p>
 
-            <p>{{ movie.description }}</p>
-
             <p class="text-danger fw-bold">AI Score: {{ '%.2f'|format(movie.score) }}</p>
             {% if movie.trailer_embed_url %}
             <div class="trailer-wrap mt-3">

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -14,7 +14,7 @@
         <input type="email" name="email" class="form-control netflix-input" value="{{ user.email or '' }}" placeholder="you@example.com">
       </div>
       <div class="col-12">
-        <label class="form-label">New Password <small class="text-muted">(optional)</small></label>
+        <label class="form-label">New Password <small class="optional-note">(optional)</small></label>
         <input type="password" name="password" class="form-control netflix-input" placeholder="Leave blank to keep current password">
       </div>
       <div class="col-12 d-flex justify-content-center mt-2">

--- a/templates/recommendations.html
+++ b/templates/recommendations.html
@@ -7,8 +7,10 @@
     <article class="movie-card">
       <img src="{{ movie.poster_url }}" alt="{{ movie.clean_title }} poster" class="movie-poster">
       <div class="movie-info">
-        <h5>{{ movie.clean_title }}</h5>
-        <p>{{ movie.pretty_genres }}</p>
+        <div class="movie-meta">
+          <h5>{{ movie.clean_title }}</h5>
+          <p>{{ movie.pretty_genres }}</p>
+        </div>
         <p class="score-chip">Match {{ '%.2f'|format(movie.score) }}</p>
         <div class="movie-actions">
           <button class="btn btn-sm netflix-btn" data-bs-toggle="modal" data-bs-target="#movieModal{{ movie.movie_id }}">View Details</button>
@@ -28,8 +30,6 @@
 
             <p><strong>Genre:</strong> {{ movie.pretty_genres }}</p>
             <p><strong>Description:</strong> {{ movie.description }}</p>
-
-            <p>{{ movie.description }}</p>
 
             {% if movie.trailer_embed_url %}
             <div class="trailer-wrap mt-3">


### PR DESCRIPTION
### Motivation
- Add playful popcorn branding to the navbar and auth screens and introduce visually engaging entrance/beaming animations to make the login/register flow feel polished and lively.
- Make profile form hints and placeholders visually subtle by rendering `(optional)` and placeholder text in light grey for better UX.
- Ensure every movie shows a playable trailer embed by providing a solid fallback when a mapped YouTube ID is missing.

### Description
- Inserted a popcorn emoji next to the `SMARTRECS` brand in `templates/base.html` and added the same popcorn icon to the auth heading in `templates/auth.html` to match requested branding.
- Added CSS animations and classes in `static/css/style.css` to create a beaming title effect, a small animated popcorn movement, and staggered entrance animations for tagline, action buttons and the auth form card; hooked those classes into `templates/auth.html`.
- Updated `templates/profile.html` to use a lighter `.optional-note` class for the `(optional)` label and added placeholder color rules so input placeholders render light grey in the profile card.
- Improved trailer logic in `app.py` so `movie_with_details()` uses the configured `TRAILER_MAP` when present and otherwise builds a YouTube embedded search fallback (`/embed?listType=search&list=...`) using `quote_plus`, guaranteeing every movie has a playable `trailer_embed_url`.
- Minor template and layout tweaks to modal/movie meta markup and flash toast markup to support animations and visuals; added 20 new movies to `data/movies.csv` and corresponding poster map entries in `POSTER_MAP`.

### Testing
- Compiled the updated application module with `python -m compileall app.py` which completed successfully.
- Ran a Python verification that iterates `movies_df` and calls `movie_with_details(...)` to assert each movie produces an embed URL starting with `https://www.youtube.com/embed`, which returned zero failures.
- Automated browser validation via a Playwright script that captured screenshots of the login/auth animations, the navbar popcorn, the profile placeholder/optional styling, and a trailer modal with a working embedded iframe; all screenshots were produced successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699adbc83f588331a781542a2dcbeb34)