### PR TITLE
Refine hero, add title/year/genre filters, and improve movie card/modal behavior

### DIFF
--- a/app.py
+++ b/app.py
@@ -59,7 +59,7 @@ POSTER_MAP = {
     "coco": "https://image.tmdb.org/t/p/w500/gGEsBPAijhVUFoiNpgZXqRVWJt2.jpg",
     "ford v ferrari": "https://image.tmdb.org/t/p/w500/dR1Ju50iudrOh3YgfwkAU1g2HZe.jpg",
     "knives out": "https://image.tmdb.org/t/p/w500/pThyQovXQrw2m0s9x82twj48Jq4.jpg",
-    "the martian": "https://image.tmdb.org/t/p/w500/5aGhaIHYuQbqlHWvWYqMCnj40y2.jpg",
+    "the martian": "https://image.tmdb.org/t/p/w500/5BHuvQ6p9kfc091Z8RiFNhCwL4b.jpg",
     "no country for old men": "https://image.tmdb.org/t/p/w500/6d5XOczc226jECq0LIX0siKtgHR.jpg",
     "the imitation game": "https://image.tmdb.org/t/p/w500/zSqJ1qFq8NXFfi7JeIYMlzyR0dx.jpg",
     "inside out": "https://image.tmdb.org/t/p/w500/2H1TmgdfNtsKlU9jKdeNyYL5y8T.jpg",
@@ -285,6 +285,28 @@ def movie_with_details(movie: dict) -> dict:
     return movie_copy
 
 
+
+
+def filter_movies(movies: list[dict], query: str, year: str, genre: str) -> list[dict]:
+    search = (query or "").strip().lower()
+    year_filter = (year or "").strip()
+    genre_filter = (genre or "").strip().lower()
+
+    def matches(movie: dict) -> bool:
+        title = str(movie.get("clean_title") or movie.get("title") or "").lower()
+        movie_year = str(movie.get("year") or "")
+        movie_genres = str(movie.get("pretty_genres") or movie.get("genres") or "").replace("|", ",").lower()
+
+        if search and search not in title:
+            return False
+        if year_filter and year_filter != movie_year:
+            return False
+        if genre_filter and genre_filter not in movie_genres:
+            return False
+        return True
+
+    return [movie for movie in movies if matches(movie)]
+
 def current_user_id() -> int | None:
     return session.get("user_id")
 
@@ -459,10 +481,15 @@ def rate_movies():
         flash("Rating saved successfully!", "success")
         return redirect(url_for("rate_movies"))
 
+    search = request.args.get("search", "")
+    year = request.args.get("year", "")
+    genre = request.args.get("genre", "")
+
     rated_ids = {r["movie_id"] for r in fetch_all("SELECT movie_id FROM user_ratings WHERE user_id = ?", (user_id,))}
     unrated = movies_df[~movies_df["movie_id"].isin(rated_ids)].to_dict(orient="records")
     detailed_movies = [movie_with_details(movie) for movie in unrated]
-    return render_template("rate.html", movies=detailed_movies, active_tab="rate")
+    filtered_movies = filter_movies(detailed_movies, search, year, genre)
+    return render_template("rate.html", movies=filtered_movies, active_tab="rate", search=search, year=year, genre=genre)
 
 
 @app.route("/recommendations")
@@ -471,7 +498,21 @@ def recommendations():
     if not user_id:
         return redirect(url_for("login"))
 
-    return render_template("recommendations.html", recommendations=get_recommendations(user_id), active_tab="recommendations")
+    search = request.args.get("search", "")
+    year = request.args.get("year", "")
+    genre = request.args.get("genre", "")
+
+    recommendations_list = get_recommendations(user_id)
+    filtered_recommendations = filter_movies(recommendations_list, search, year, genre)
+
+    return render_template(
+        "recommendations.html",
+        recommendations=filtered_recommendations,
+        active_tab="recommendations",
+        search=search,
+        year=year,
+        genre=genre,
+    )
 
 
 if __name__ == "__main__":

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -404,3 +404,86 @@ body.page-leave { opacity: .25; transform: translateY(6px); }
   text-align: center;
   line-height: 1.6;
 }
+
+/* refinement updates */
+.netflix-hero {
+  padding: 4.5rem 0 2.75rem;
+  min-height: 56vh;
+}
+.hero-intro-block {
+  min-height: 44vh;
+}
+.hero-intro-block h1 {
+  margin-top: .4rem;
+}
+.hero-stats {
+  margin-top: 1.6rem !important;
+}
+
+.movie-filter-form {
+  width: min(980px, 100%);
+  margin: 0 auto 1.2rem;
+  padding: .9rem;
+  border: 1px solid rgba(255,255,255,.16);
+  border-radius: 14px;
+  background: rgba(17,20,32,.72);
+  backdrop-filter: blur(8px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: .65rem;
+  flex-wrap: wrap;
+}
+.filter-field {
+  flex: 1 1 220px;
+  min-width: 180px;
+}
+.filter-small {
+  flex: 0 1 130px;
+  min-width: 110px;
+}
+
+.movie-grid,
+.movie-row {
+  align-items: stretch;
+}
+.movie-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+.movie-info {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+.movie-meta {
+  min-height: 96px;
+}
+.star-form {
+  margin-top: auto;
+}
+.star-action-row {
+  margin-top: .55rem;
+}
+
+.cool-modal-title {
+  width: 100%;
+  text-align: center;
+  font-weight: 800;
+  letter-spacing: .45px;
+}
+.cool-description {
+  text-align: center;
+  font-family: "Trebuchet MS", "Gill Sans", "Segoe UI", sans-serif;
+  line-height: 1.65;
+  font-size: 1.08rem;
+  color: #eff3ff;
+}
+
+@media (max-width: 768px) {
+  .movie-filter-form {
+    padding: .75rem;
+  }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -104,6 +104,17 @@
     }, { threshold: 0.12 });
 
     revealTargets.forEach((el) => observer.observe(el));
+
+
+    document.querySelectorAll('.modal').forEach((modalEl) => {
+      modalEl.addEventListener('hidden.bs.modal', () => {
+        modalEl.querySelectorAll('iframe.trailer-iframe').forEach((frame) => {
+          const originalSrc = frame.dataset.src || frame.src;
+          frame.src = '';
+          requestAnimationFrame(() => { frame.src = originalSrc; });
+        });
+      });
+    });
   </script>
 </body>
 </html>

--- a/templates/rate.html
+++ b/templates/rate.html
@@ -1,6 +1,23 @@
 {% extends 'base.html' %}
 {% block content %}
 <section class="container py-5">
+  <form method="get" class="movie-filter-form">
+    <div class="filter-field">
+      <label for="rateSearch" class="visually-hidden">Search titles</label>
+      <input id="rateSearch" type="text" name="search" value="{{ search }}" class="form-control netflix-input" placeholder="Search movie title">
+    </div>
+    <div class="filter-field filter-small">
+      <label for="rateYear" class="visually-hidden">Filter year</label>
+      <input id="rateYear" type="text" inputmode="numeric" pattern="[0-9]{4}" maxlength="4" name="year" value="{{ year }}" class="form-control netflix-input" placeholder="Year">
+    </div>
+    <div class="filter-field">
+      <label for="rateGenre" class="visually-hidden">Filter genre</label>
+      <input id="rateGenre" type="text" name="genre" value="{{ genre }}" class="form-control netflix-input" placeholder="Genre">
+    </div>
+    <button class="btn netflix-btn" type="submit">Filter</button>
+    <a class="btn btn-outline-light" href="{{ url_for('rate_movies') }}">Reset</a>
+  </form>
+
   <h1 class="row-title mb-4">Rate Movies</h1>
   <div class="movie-grid">
     {% for movie in movies[:60] %}
@@ -32,21 +49,21 @@
       <div class="modal-dialog modal-lg modal-dialog-centered">
         <div class="modal-content netflix-modal">
           <div class="modal-header border-0">
-            <h5 class="modal-title">{{ movie.clean_title }} ({{ movie.year }})</h5>
+            <h5 class="modal-title cool-modal-title">{{ movie.clean_title }} ({{ movie.year }})</h5>
             <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
           </div>
           <div class="modal-body">
             <p><strong>Release date:</strong> {{ movie.release_date }}</p>
 
             <p><strong>Genre:</strong> {{ movie.pretty_genres }}</p>
-            <p class="movie-description"><strong>Description:</strong> {{ movie.description }}</p>
+            <p class="movie-description cool-description"><strong>Description:</strong> {{ movie.description }}</p>
 
 
             {% if movie.trailer_embed_url %}
             <div class="trailer-wrap mt-3">
               <h6>Watch Trailer</h6>
               <div class="ratio ratio-16x9 trailer-frame">
-                <iframe src="{{ movie.trailer_embed_url }}" title="{{ movie.clean_title }} trailer" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                <iframe src="{{ movie.trailer_embed_url }}" data-src="{{ movie.trailer_embed_url }}" class="trailer-iframe" title="{{ movie.clean_title }} trailer" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
               </div>
             </div>
             {% endif %}

--- a/templates/recommendations.html
+++ b/templates/recommendations.html
@@ -1,6 +1,23 @@
 {% extends 'base.html' %}
 {% block content %}
 <section class="container py-5">
+  <form method="get" class="movie-filter-form">
+    <div class="filter-field">
+      <label for="listSearch" class="visually-hidden">Search titles</label>
+      <input id="listSearch" type="text" name="search" value="{{ search }}" class="form-control netflix-input" placeholder="Search movie title">
+    </div>
+    <div class="filter-field filter-small">
+      <label for="listYear" class="visually-hidden">Filter year</label>
+      <input id="listYear" type="text" inputmode="numeric" pattern="[0-9]{4}" maxlength="4" name="year" value="{{ year }}" class="form-control netflix-input" placeholder="Year">
+    </div>
+    <div class="filter-field">
+      <label for="listGenre" class="visually-hidden">Filter genre</label>
+      <input id="listGenre" type="text" name="genre" value="{{ genre }}" class="form-control netflix-input" placeholder="Genre">
+    </div>
+    <button class="btn netflix-btn" type="submit">Filter</button>
+    <a class="btn btn-outline-light" href="{{ url_for('recommendations') }}">Reset</a>
+  </form>
+
   <h1 class="row-title">Recommended For You</h1>
   <div class="movie-grid">
     {% for movie in recommendations %}
@@ -22,20 +39,20 @@
       <div class="modal-dialog modal-lg modal-dialog-centered">
         <div class="modal-content netflix-modal">
           <div class="modal-header border-0">
-            <h5 class="modal-title">{{ movie.clean_title }} ({{ movie.year }})</h5>
+            <h5 class="modal-title cool-modal-title">{{ movie.clean_title }} ({{ movie.year }})</h5>
             <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
           </div>
           <div class="modal-body">
             <p><strong>Release date:</strong> {{ movie.release_date }}</p>
 
             <p><strong>Genre:</strong> {{ movie.pretty_genres }}</p>
-            <p class="movie-description"><strong>Description:</strong> {{ movie.description }}</p>
+            <p class="movie-description cool-description"><strong>Description:</strong> {{ movie.description }}</p>
 
             {% if movie.trailer_embed_url %}
             <div class="trailer-wrap mt-3">
               <h6>Watch Trailer</h6>
               <div class="ratio ratio-16x9 trailer-frame">
-                <iframe src="{{ movie.trailer_embed_url }}" title="{{ movie.clean_title }} trailer" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                <iframe src="{{ movie.trailer_embed_url }}" data-src="{{ movie.trailer_embed_url }}" class="trailer-iframe" title="{{ movie.clean_title }} trailer" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
               </div>
             </div>
             {% endif %}


### PR DESCRIPTION
### Motivation
- Make the dashboard hero less dominant so “Top Picks For You” appears higher on full-screen layouts. 
- Provide a simple way to filter movies by title, year, and genre on Rate and My List pages. 
- Improve modal presentation and ensure trailer playback stops when a modal is closed. 
- Eliminate awkward vertical gaps under rating stars and action buttons in movie cards.

### Description
- Reduced hero vertical padding/height and tightened stat spacing in `static/css/style.css` to surface the picks row sooner. 
- Replaced the poster URL for **The Martian** in `POSTER_MAP` to a reliable cover image. 
- Added a `filter_movies` helper and wired query-param filtering for `search`, `year`, and `genre` into the `/rate` and `/recommendations` routes in `app.py`. 
- Added centered, styled filter forms above the page titles in `templates/rate.html` and `templates/recommendations.html` to filter title/year/genre and include `Filter`/`Reset` controls. 
- Styled modal movie title and description (`.cool-modal-title`, `.cool-description`) and made movie cards stretch so actions/ratings sit flush at the bottom (`.movie-card`, `.movie-info`, `.star-form`) in `static/css/style.css`. 
- Made trailer iframes lazy-annotated (`data-src` + `.trailer-iframe`) and added JS in `templates/base.html` to clear and restore iframe `src` on `hidden.bs.modal` so playback stops when modals close.

### Testing
- Compiled the server file with `python -m py_compile app.py` and it succeeded. 
- Launched the app locally and captured UI screenshots with Playwright to verify dashboard and filtered Rate views (artifacts created). 
- Ran a quick check of poster resolution by calling `movie_with_details(...)` for The Martian and confirmed the new poster URL is returned. 
- Verified the app serves the filtered routes in a running server session and that closing modals resets trailer playback via browser verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b175f62288331bf48f9eec806387d)