### PR TITLE
Auto-login after registration; restore modal text styling; add filters and placeholder color

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -401,6 +401,94 @@ body.page-leave { opacity: .25; transform: translateY(6px); }
 }
 
 .movie-description {
-  text-align: center;
+  text-align: left;
   line-height: 1.6;
+  color: #e9edf7;
+  margin-bottom: .65rem;
+}
+.netflix-modal .modal-body p strong {
+  color: #ff4a58;
+  font-weight: 800;
+}
+
+/* refinement updates */
+.netflix-hero {
+  padding: 4.5rem 0 2.75rem;
+  min-height: 56vh;
+}
+.hero-intro-block {
+  min-height: 44vh;
+}
+.hero-intro-block h1 {
+  margin-top: .4rem;
+}
+.hero-stats {
+  margin-top: 1.6rem !important;
+}
+
+.movie-filter-form {
+  width: min(980px, 100%);
+  margin: 0 auto 1.2rem;
+  padding: .9rem;
+  border: 1px solid rgba(255,255,255,.16);
+  border-radius: 14px;
+  background: rgba(17,20,32,.72);
+  backdrop-filter: blur(8px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: .65rem;
+  flex-wrap: wrap;
+}
+.filter-field {
+  flex: 1 1 220px;
+  min-width: 180px;
+}
+.filter-small {
+  flex: 0 1 130px;
+  min-width: 110px;
+}
+.movie-filter-form .netflix-input::placeholder {
+  color: #c8ceda;
+  opacity: 1;
+}
+
+.movie-grid,
+.movie-row {
+  align-items: stretch;
+}
+.movie-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+.movie-info {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+.movie-meta {
+  min-height: 96px;
+}
+.star-form {
+  margin-top: auto;
+}
+.star-action-row {
+  margin-top: .55rem;
+}
+
+.cool-modal-title {
+  width: 100%;
+  text-align: center;
+  font-weight: 900;
+  letter-spacing: .55px;
+  color: #ff5169;
+  text-shadow: 0 0 10px rgba(229,9,20,.45), 0 0 20px rgba(229,9,20,.28);
+}
+
+@media (max-width: 768px) {
+  .movie-filter-form {
+    padding: .75rem;
+  }
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -104,6 +104,17 @@
     }, { threshold: 0.12 });
 
     revealTargets.forEach((el) => observer.observe(el));
+
+
+    document.querySelectorAll('.modal').forEach((modalEl) => {
+      modalEl.addEventListener('hidden.bs.modal', () => {
+        modalEl.querySelectorAll('iframe.trailer-iframe').forEach((frame) => {
+          const originalSrc = frame.dataset.src || frame.src;
+          frame.src = '';
+          requestAnimationFrame(() => { frame.src = originalSrc; });
+        });
+      });
+    });
   </script>
 </body>
 </html>

--- a/templates/rate.html
+++ b/templates/rate.html
@@ -1,6 +1,23 @@
 {% extends 'base.html' %}
 {% block content %}
 <section class="container py-5">
+  <form method="get" class="movie-filter-form">
+    <div class="filter-field">
+      <label for="rateSearch" class="visually-hidden">Search titles</label>
+      <input id="rateSearch" type="text" name="search" value="{{ search }}" class="form-control netflix-input" placeholder="Search movie title">
+    </div>
+    <div class="filter-field filter-small">
+      <label for="rateYear" class="visually-hidden">Filter year</label>
+      <input id="rateYear" type="text" inputmode="numeric" pattern="[0-9]{4}" maxlength="4" name="year" value="{{ year }}" class="form-control netflix-input" placeholder="Year">
+    </div>
+    <div class="filter-field">
+      <label for="rateGenre" class="visually-hidden">Filter genre</label>
+      <input id="rateGenre" type="text" name="genre" value="{{ genre }}" class="form-control netflix-input" placeholder="Genre">
+    </div>
+    <button class="btn netflix-btn" type="submit">Filter</button>
+    <a class="btn btn-outline-light" href="{{ url_for('rate_movies') }}">Reset</a>
+  </form>
+
   <h1 class="row-title mb-4">Rate Movies</h1>
   <div class="movie-grid">
     {% for movie in movies[:60] %}
@@ -32,7 +49,7 @@
       <div class="modal-dialog modal-lg modal-dialog-centered">
         <div class="modal-content netflix-modal">
           <div class="modal-header border-0">
-            <h5 class="modal-title">{{ movie.clean_title }} ({{ movie.year }})</h5>
+            <h5 class="modal-title cool-modal-title">{{ movie.clean_title }} ({{ movie.year }})</h5>
             <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
           </div>
           <div class="modal-body">
@@ -46,7 +63,7 @@
             <div class="trailer-wrap mt-3">
               <h6>Watch Trailer</h6>
               <div class="ratio ratio-16x9 trailer-frame">
-                <iframe src="{{ movie.trailer_embed_url }}" title="{{ movie.clean_title }} trailer" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                <iframe src="{{ movie.trailer_embed_url }}" data-src="{{ movie.trailer_embed_url }}" class="trailer-iframe" title="{{ movie.clean_title }} trailer" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
               </div>
             </div>
             {% endif %}

--- a/templates/recommendations.html
+++ b/templates/recommendations.html
@@ -1,6 +1,23 @@
 {% extends 'base.html' %}
 {% block content %}
 <section class="container py-5">
+  <form method="get" class="movie-filter-form">
+    <div class="filter-field">
+      <label for="listSearch" class="visually-hidden">Search titles</label>
+      <input id="listSearch" type="text" name="search" value="{{ search }}" class="form-control netflix-input" placeholder="Search movie title">
+    </div>
+    <div class="filter-field filter-small">
+      <label for="listYear" class="visually-hidden">Filter year</label>
+      <input id="listYear" type="text" inputmode="numeric" pattern="[0-9]{4}" maxlength="4" name="year" value="{{ year }}" class="form-control netflix-input" placeholder="Year">
+    </div>
+    <div class="filter-field">
+      <label for="listGenre" class="visually-hidden">Filter genre</label>
+      <input id="listGenre" type="text" name="genre" value="{{ genre }}" class="form-control netflix-input" placeholder="Genre">
+    </div>
+    <button class="btn netflix-btn" type="submit">Filter</button>
+    <a class="btn btn-outline-light" href="{{ url_for('recommendations') }}">Reset</a>
+  </form>
+
   <h1 class="row-title">Recommended For You</h1>
   <div class="movie-grid">
     {% for movie in recommendations %}
@@ -22,7 +39,7 @@
       <div class="modal-dialog modal-lg modal-dialog-centered">
         <div class="modal-content netflix-modal">
           <div class="modal-header border-0">
-            <h5 class="modal-title">{{ movie.clean_title }} ({{ movie.year }})</h5>
+            <h5 class="modal-title cool-modal-title">{{ movie.clean_title }} ({{ movie.year }})</h5>
             <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
           </div>
           <div class="modal-body">
@@ -35,7 +52,7 @@
             <div class="trailer-wrap mt-3">
               <h6>Watch Trailer</h6>
               <div class="ratio ratio-16x9 trailer-frame">
-                <iframe src="{{ movie.trailer_embed_url }}" title="{{ movie.clean_title }} trailer" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                <iframe src="{{ movie.trailer_embed_url }}" data-src="{{ movie.trailer_embed_url }}" class="trailer-iframe" title="{{ movie.clean_title }} trailer" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
               </div>
             </div>
             {% endif %}


### PR DESCRIPTION
### Motivation
- Ensure new users are immediately logged in after signing up so they land on the dashboard as required. 
- Restore the modal movie text layout and visual emphasis to match the requested format (centered red-glow title and red labels) while keeping trailer behavior and actions intact. 
- Provide simple client-side filters (title/year/genre) on the `Rate` and `Recommended` pages and make filter placeholders visually subtle.

### Description
- Sign-in immediately after successful registration by setting `session['user_id']`, `session['username']`, and `session['email']` and redirecting to `dashboard` in `app.py` (auto-login on register). 
- Added `filter_movies` helper and wired query-param filtering (`search`, `year`, `genre`) into the `/rate` and `/recommendations` routes and templates, passing `search`, `year`, and `genre` context values. 
- Restored modal description layout by using the original description class and left-aligned body text, and added `.netflix-modal .modal-body p strong` rules to color labels red and bold them in `static/css/style.css`. 
- Made modal titles centered with a red glow by updating `.cool-modal-title` and ensured trailer iframes use `data-src` + `.trailer-iframe` and added JS in `templates/base.html` to clear/restore iframe `src` on `hidden.bs.modal` so playback stops when modals close. 
- Set filter input placeholder color to a light grey via `.movie-filter-form .netflix-input::placeholder` in `static/css/style.css` and added the filter forms to `templates/rate.html` and `templates/recommendations.html`.

### Testing
- `python -m py_compile app.py` was run and succeeded. 
- A Flask test-client check posted to `/register` and verified a `302` redirect to `/dashboard` and that the session contains `user_id`, which succeeded. 
- A Playwright-driven browser verification exercised the `register -> dashboard` flow and opened a modal on a filtered `rate` page and captured screenshots (artifacts created), which validated UI changes. 
- The development server was started for manual/browser verification and ran without errors during the checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b175f62288331bf48f9eec806387d)