### PR TITLE
Define missing TRAILER_SEARCH_QUERY_MAP to prevent NameError

### DIFF
--- a/app.py
+++ b/app.py
@@ -173,6 +173,9 @@ TRAILER_MAP = {
     "how to train your dragon": "22w7z_lT6YM",
 }
 
+# Optional overrides for YouTube trailer search phrases when no direct trailer ID is set.
+TRAILER_SEARCH_QUERY_MAP = {}
+
 
 EXACT_DESCRIPTIONS = {
     "inception": "A thief who steals corporate secrets through dream-sharing technology is tasked with planting an idea into a CEO's mind.",


### PR DESCRIPTION
### Motivation
- Prevent a `NameError` when building fallback YouTube trailer search URLs in `movie_with_details` by ensuring `TRAILER_SEARCH_QUERY_MAP` exists.

### Description
- Add a module-level `TRAILER_SEARCH_QUERY_MAP = {}` with a brief comment so per-title override queries can be provided later without changing behavior today.

### Testing
- Ran `python -m py_compile app.py` successfully to validate there are no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c7352ca3c83319ba5b07cb1945ed2)