### PR TITLE
Preserve rated movies on rate page, add reset endpoint, and stream play button

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -659,3 +659,37 @@ body.page-leave { opacity: .25; transform: translateY(6px); }
   margin-bottom: 0;
   line-height: 1;
 }
+
+.hero-action-buttons {
+  display: flex;
+  align-items: center;
+  gap: .7rem;
+  flex-wrap: wrap;
+}
+
+.reset-ratings-form {
+  margin: 0;
+}
+
+.stream-label {
+  color: var(--nf-red);
+}
+
+.stream-play-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  margin-left: .35rem;
+  border-radius: 999px;
+  text-decoration: none;
+  color: #fff;
+  background: var(--nf-red);
+  box-shadow: 0 0 14px rgba(229, 9, 20, .72);
+}
+
+.stream-play-btn:hover {
+  color: #fff;
+  transform: translateY(-1px);
+}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -4,12 +4,17 @@
   <div class="container hero-content-wrap hero-intro-block">
     <h1>Welcome back, {{ session.get('username', 'Viewer')|title }}</h1>
     <p>Your movie night dashboard with AI-personalized picks.</p>
-    <a href="{{ url_for('rate_movies') }}" class="btn netflix-btn page-shift">Rate Movies</a>
+    <div class="hero-action-buttons">
+      <a href="{{ url_for('rate_movies') }}" class="btn netflix-btn page-shift">Rate Movies</a>
+      <form method="post" action="{{ url_for('reset_ratings') }}" class="reset-ratings-form">
+        <button type="submit" class="btn btn-success">Reset</button>
+      </form>
+    </div>
 
     <div class="row g-3 hero-stats">
       <div class="col-md-4"><div class="nf-stat stat-float"><span>Movies Rated</span><strong>{{ rating_count }}</strong></div></div>
-      <div class="col-md-4"><div class="nf-stat stat-float stat-delay-1"><span>Top Genre</span><strong>{{ top_genre }}</strong></div></div>
-      <div class="col-md-4"><div class="nf-stat stat-float stat-delay-2"><span>Match Score</span><strong>{{ score_pct }}%</strong></div></div>
+      <div class="col-md-4"><div class="nf-stat stat-float stat-delay-1"><span>Top Genre</span><strong>{{ top_genre if rating_count else "" }}</strong></div></div>
+      <div class="col-md-4"><div class="nf-stat stat-float stat-delay-2"><span>Match Score</span><strong>{{ (score_pct ~ "%") if rating_count else "" }}</strong></div></div>
     </div>
   </div>
 </section>
@@ -41,6 +46,11 @@
             <p><strong>Release date:</strong> {{ movie.release_date }}</p>
             <p><strong>Genre:</strong> {{ movie.pretty_genres }}</p>
             <p class="movie-description"><strong>Description:</strong> {{ movie.description }}</p>
+            <p><strong class="stream-label">Stream:</strong>
+              <a href="https://cineb.gg/" target="_blank" rel="noopener noreferrer" class="stream-play-btn" aria-label="Stream {{ movie.clean_title }} on cineb">
+                <i class="bi bi-play-fill"></i>
+              </a>
+            </p>
 
             <p class="text-danger fw-bold">Match Score: {{ '%.2f'|format(movie.score) }}</p>
             {% if movie.trailer_embed_url %}

--- a/templates/rate.html
+++ b/templates/rate.html
@@ -37,7 +37,7 @@
           <div class="star-action-row">
             <div class="rating-stars">
               {% for value in [5,4,3,2,1] %}
-              <input type="radio" id="star{{ movie.movie_id }}-{{ value }}" name="rating" value="{{ value }}" required>
+              <input type="radio" id="star{{ movie.movie_id }}-{{ value }}" name="rating" value="{{ value }}" {% if movie.user_rating and movie.user_rating|int == value %}checked{% endif %} required>
               <label for="star{{ movie.movie_id }}-{{ value }}">★</label>
               {% endfor %}
             </div>
@@ -59,6 +59,11 @@
 
             <p><strong>Genre:</strong> {{ movie.pretty_genres }}</p>
             <p class="movie-description cool-description"><strong>Description:</strong> {{ movie.description }}</p>
+            <p><strong class="stream-label">Stream:</strong>
+              <a href="https://cineb.gg/" target="_blank" rel="noopener noreferrer" class="stream-play-btn" aria-label="Stream {{ movie.clean_title }} on cineb">
+                <i class="bi bi-play-fill"></i>
+              </a>
+            </p>
 
 
             {% if movie.trailer_embed_url %}

--- a/templates/recommendations.html
+++ b/templates/recommendations.html
@@ -19,6 +19,9 @@
   </form>
 
   <h1 class="row-title">Recommended For You</h1>
+  {% if not has_ratings %}
+  <p class="text-muted">Rate movies to see personalized match scores.</p>
+  {% endif %}
   <div class="movie-grid">
     {% for movie in recommendations %}
     <article class="movie-card">
@@ -28,7 +31,11 @@
           <h5>{{ movie.clean_title }}</h5>
           <p>{{ movie.pretty_genres }}</p>
         </div>
+        {% if movie.score and movie.score > 0 %}
         <p class="score-chip">Match {{ '%.2f'|format(movie.score) }}</p>
+        {% elif movie.is_rated %}
+        <p class="score-chip">Rated {{ movie.user_rating|int }}/5</p>
+        {% endif %}
         <div class="movie-actions">
           <button class="btn btn-sm netflix-btn" data-bs-toggle="modal" data-bs-target="#movieModal{{ movie.movie_id }}">View Details</button>
         </div>
@@ -47,6 +54,11 @@
 
             <p><strong>Genre:</strong> {{ movie.pretty_genres }}</p>
             <p class="movie-description cool-description"><strong>Description:</strong> {{ movie.description }}</p>
+            <p><strong class="stream-label">Stream:</strong>
+              <a href="https://cineb.gg/" target="_blank" rel="noopener noreferrer" class="stream-play-btn" aria-label="Stream {{ movie.clean_title }} on cineb">
+                <i class="bi bi-play-fill"></i>
+              </a>
+            </p>
 
             {% if movie.trailer_embed_url %}
             <div class="trailer-wrap mt-3">


### PR DESCRIPTION
### Motivation
- Ensure movies that have been rated remain visible on the `Rate Movies` page and keep the selected star (yellow) after saving so the UI reflects the persisted rating.
- Surface user-rated items on the `Recommendations` page so users can see what they rated alongside model picks.
- Provide a single-click way to reset the app back to first-visit state (no ratings, no top genre, no match score) via the dashboard.
- Add a visual "Stream" row with a red play button linking to `https://cineb.gg/` under movie descriptions across pages for easy streaming access.

### Description
- Added `get_user_rated_movies(user_id)` and updated `recommendations()` to merge rated movies into model recommendations without duplication and expose `has_ratings` to the template.
- Modified `rate_movies()` to attach `user_rating` to every movie detail so templates can pre-check the matching radio input and keep the star highlighted after saving.
- Added a new POST route ` /reset-ratings ` that deletes the current users ratings and clears the recommendations cache, and updated the dashboard to include a green `Reset` button next to `Rate Movies` and to hide `Top Genre`/`Match Score` when there are no ratings.
- Updated templates `rate.html`, `recommendations.html`, and `dashboard.html` to show the `Stream` label and a red glowing play button linking to `https://cineb.gg/`, and updated CSS (`static/css/style.css`) with `.stream-play-btn` and `.hero-action-buttons` styles.

### Testing
- Ran `python -m compileall app.py templates static/css/style.css` to validate there are no syntax errors, and it completed successfully.
- Started the app with `python app.py` and exercised routes (register/login/dashboard) to verify the new UI elements and route behavior during manual automated runs.
- Captured a Playwright screenshot as automated visual validation to confirm the dashboard Rate/Reset actions and modal stream play button render correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c9acb50188331abd13432e3d66487)