### PR TITLE
Improve auth UX, dashboard placeholders, and trailer/modal performance

### DIFF
--- a/templates/auth.html
+++ b/templates/auth.html
@@ -40,8 +40,8 @@
         {% else %}
         <form method="post" action="{{ url_for('login') }}">
           <div class="mb-3">
-            <label class="form-label">Username</label>
-            <input name="username" class="form-control netflix-input" placeholder="John" required>
+            <label class="form-label">Username or Email</label>
+            <input name="identity" class="form-control netflix-input" placeholder="John or name@email.com" required>
           </div>
           <div class="mb-3">
             <label class="form-label">Password</label>

--- a/templates/base.html
+++ b/templates/base.html
@@ -107,11 +107,17 @@
 
 
     document.querySelectorAll('.modal').forEach((modalEl) => {
-      modalEl.addEventListener('hidden.bs.modal', () => {
+      modalEl.addEventListener('shown.bs.modal', () => {
         modalEl.querySelectorAll('iframe.trailer-iframe').forEach((frame) => {
-          const originalSrc = frame.dataset.src || frame.src;
-          frame.src = '';
-          requestAnimationFrame(() => { frame.src = originalSrc; });
+          if (!frame.src || frame.src === 'about:blank') {
+            frame.src = frame.dataset.src || 'about:blank';
+          }
+        });
+      });
+
+      modalEl.addEventListener('hide.bs.modal', () => {
+        modalEl.querySelectorAll('iframe.trailer-iframe').forEach((frame) => {
+          frame.src = 'about:blank';
         });
       });
     });

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -13,8 +13,8 @@
 
     <div class="row g-3 hero-stats">
       <div class="col-md-4"><div class="nf-stat stat-float"><span>Movies Rated</span><strong>{{ rating_count }}</strong></div></div>
-      <div class="col-md-4"><div class="nf-stat stat-float stat-delay-1"><span>Top Genre</span><strong>{{ top_genre if rating_count else "" }}</strong></div></div>
-      <div class="col-md-4"><div class="nf-stat stat-float stat-delay-2"><span>Match Score</span><strong>{{ (score_pct ~ "%") if rating_count else "" }}</strong></div></div>
+      <div class="col-md-4"><div class="nf-stat stat-float stat-delay-1"><span>Top Genre</span><strong>{{ top_genre if rating_count else "N/A" }}</strong></div></div>
+      <div class="col-md-4"><div class="nf-stat stat-float stat-delay-2"><span>Match Score</span><strong>{{ (score_pct ~ "%") if rating_count else "0%" }}</strong></div></div>
     </div>
   </div>
 </section>
@@ -57,7 +57,7 @@
             <div class="trailer-wrap mt-3">
               <h6>Watch Trailer</h6>
               <div class="ratio ratio-16x9 trailer-frame">
-                <iframe src="{{ movie.trailer_embed_url }}" title="{{ movie.clean_title }} trailer" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                <iframe src="about:blank" data-src="{{ movie.trailer_embed_url }}" class="trailer-iframe" loading="lazy" title="{{ movie.clean_title }} trailer" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
               </div>
             </div>
             {% endif %}


### PR DESCRIPTION
### Motivation
- Users were forced to re-register and the login UX accepted only usernames, causing friction and confusion.  
- Movie detail enrichment and poster/trailer resolution were performed repeatedly, slowing pages and increasing latency.  
- Trailer iframes continued playing after closing the modal, and the dashboard showed empty placeholders when the user had no ratings.

### Description
- Prevent duplicate registrations by checking for an existing username or email during `register` and redirecting existing users to the login flow with a warning. (app.py)  
- Allow signing in using either username or email by accepting an `identity` field and searching users by username OR email. (app.py, templates/auth.html)  
- Add a cached movie-details path (`_movie_details_cached` + `movie_with_details_cached`) and switch recommendation, rated-movies, and rate-page flows to use it to reduce repeated metadata/poster/trailer lookups. (app.py)  
- Show friendly dashboard placeholders when no rated movies exist by rendering `Top Genre: N/A` and `Match Score: 0%`. (templates/dashboard.html)  
- Lazy-load trailer iframe sources and immediately teardown playback on modal close by using `data-src`/`about:blank`, setting `src` on `shown.bs.modal` and clearing it on `hide.bs.modal` so trailers stop when the modal is closed. (templates/base.html, templates/dashboard.html)

### Testing
- Ran Python syntax check with `python -m py_compile app.py`, which succeeded.  
- Performed Flask test-client smoke checks to assert `/register` and `/login` pages return `200` and that an invalid login post returns the expected response; those checks succeeded.  
- Attempted a full Playwright end-to-end script (timed out in the long scenario), then ran a smaller Playwright script to capture the login form screenshot which succeeded and produced a verification artifact for the updated UI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ca3ed4b2c8331bda894f220d71afb)