### PR TITLE
Show dashboard first and move sign-in/register into guest popup modal

### DIFF
--- a/app.py
+++ b/app.py
@@ -407,20 +407,21 @@ def load_app_ratings() -> pd.DataFrame:
 
 @app.route("/")
 def index():
-    if current_user_id():
-        return redirect(url_for("dashboard"))
-    return redirect(url_for("login"))
+    return redirect(url_for("dashboard"))
 
 
 @app.route("/register", methods=["GET", "POST"])
 def register():
+    if current_user_id():
+        return redirect(url_for("dashboard"))
+
     if request.method == "POST":
         username = request.form["username"].strip().lower()
         email = request.form.get("email", "").strip().lower() or None
         password = request.form["password"]
         if len(password) < 8:
             flash("Password must be at least 8 characters.", "danger")
-            return render_template("register.html", auth_mode="register", auth_page=True)
+            return redirect(url_for("dashboard", auth="register"))
 
         existing_user = fetch_one(
             "SELECT id FROM users WHERE username = ? OR (email IS NOT NULL AND email = ?)",
@@ -428,7 +429,7 @@ def register():
         )
         if existing_user:
             flash("Account already exists. Please sign in instead.", "warning")
-            return redirect(url_for("login", mode="login"))
+            return redirect(url_for("dashboard", auth="login"))
 
         password_hash = generate_password_hash(password)
         try:
@@ -442,13 +443,16 @@ def register():
             return redirect(url_for("dashboard"))
         except Exception:
             flash("Username already exists.", "danger")
+            return redirect(url_for("dashboard", auth="register"))
 
-    mode = request.args.get("mode") or ("register" if request.method == "POST" else None)
-    return render_template("register.html", auth_mode=mode, auth_page=True)
+    return redirect(url_for("dashboard", auth="register"))
 
 
 @app.route("/login", methods=["GET", "POST"])
 def login():
+    if current_user_id():
+        return redirect(url_for("dashboard"))
+
     if request.method == "POST":
         identity = request.form["identity"].strip().lower()
         password = request.form["password"]
@@ -465,27 +469,28 @@ def login():
             return redirect(url_for("dashboard"))
 
         flash("Invalid credentials.", "danger")
+        return redirect(url_for("dashboard", auth="login"))
 
-    mode = request.args.get("mode") or ("login" if request.method == "POST" else None)
-    return render_template("login.html", auth_mode=mode, auth_page=True)
+    return redirect(url_for("dashboard", auth="login"))
 
 
 @app.route("/logout")
 def logout():
     session.clear()
-    return redirect(url_for("login"))
+    return redirect(url_for("dashboard"))
 
 
 @app.route("/profile", methods=["GET", "POST"])
 def profile():
     user_id = current_user_id()
     if not user_id:
-        return redirect(url_for("login"))
+        flash("Please sign in to open your profile.", "warning")
+        return redirect(url_for("dashboard", auth="login"))
 
     user = fetch_one("SELECT id, username, email, password_hash FROM users WHERE id = ?", (user_id,))
     if not user:
         session.clear()
-        return redirect(url_for("login"))
+        return redirect(url_for("dashboard", auth="login"))
 
     if request.method == "POST":
         new_username = request.form["username"].strip().lower()
@@ -516,32 +521,46 @@ def profile():
 @app.route("/dashboard")
 def dashboard():
     user_id = current_user_id()
-    if not user_id:
-        return redirect(url_for("login"))
+    auth_mode = request.args.get("auth")
 
-    ratings = fetch_all("SELECT movie_id, rating FROM user_ratings WHERE user_id = ?", (user_id,))
-    rating_count = len(ratings)
-
+    rating_count = 0
     top_genre = "N/A"
     score_pct = 0
-    if ratings:
-        rated_movie_ids = [r["movie_id"] for r in ratings]
-        rated_movies = movies_df[movies_df["movie_id"].isin(rated_movie_ids)]
-        genre_counter = Counter()
-        for genre_str in rated_movies["genres"]:
-            for genre in genre_str.split("|"):
-                genre_counter[genre] += 1
-        if genre_counter:
-            top_genre = genre_counter.most_common(1)[0][0]
-        avg_rating = sum(r["rating"] for r in ratings) / rating_count
-        score_pct = int((avg_rating / 5.0) * 100)
+    recommendations = []
+
+    if user_id:
+        ratings = fetch_all("SELECT movie_id, rating FROM user_ratings WHERE user_id = ?", (user_id,))
+        rating_count = len(ratings)
+
+        if ratings:
+            rated_movie_ids = [r["movie_id"] for r in ratings]
+            rated_movies = movies_df[movies_df["movie_id"].isin(rated_movie_ids)]
+            genre_counter = Counter()
+            for genre_str in rated_movies["genres"]:
+                for genre in genre_str.split("|"):
+                    genre_counter[genre] += 1
+            if genre_counter:
+                top_genre = genre_counter.most_common(1)[0][0]
+            avg_rating = sum(r["rating"] for r in ratings) / rating_count
+            score_pct = int((avg_rating / 5.0) * 100)
+        recommendations = get_recommendations(user_id)
+    else:
+        auth_mode = auth_mode if auth_mode in {"login", "register"} else None
+        guest_movies = movies_df.head(12).to_dict(orient="records")
+        recommendations = []
+        for movie in guest_movies:
+            movie_detail = movie_with_details_cached(movie)
+            movie_detail["score"] = 0
+            recommendations.append(movie_detail)
 
     return render_template(
         "dashboard.html",
         rating_count=rating_count,
         top_genre=top_genre,
         score_pct=score_pct,
-        recommendations=get_recommendations(user_id),
+        recommendations=recommendations,
+        auth_mode=auth_mode,
+        is_guest=not bool(user_id),
         active_tab="dashboard",
     )
 
@@ -597,7 +616,8 @@ def get_user_rated_movies(user_id: int) -> list[dict]:
 def rate_movies():
     user_id = current_user_id()
     if not user_id:
-        return redirect(url_for("login"))
+        flash("Please sign in to rate movies.", "warning")
+        return redirect(url_for("dashboard", auth="login"))
 
     if request.method == "POST":
         movie_id = int(request.form["movie_id"])
@@ -636,7 +656,8 @@ def rate_movies():
 def recommendations():
     user_id = current_user_id()
     if not user_id:
-        return redirect(url_for("login"))
+        flash("Please sign in to view your list.", "warning")
+        return redirect(url_for("dashboard", auth="login"))
 
     search = request.args.get("search", "")
     year = request.args.get("year", "")
@@ -671,7 +692,8 @@ def recommendations():
 def reset_ratings():
     user_id = current_user_id()
     if not user_id:
-        return redirect(url_for("login"))
+        flash("Please sign in to reset ratings.", "warning")
+        return redirect(url_for("dashboard", auth="login"))
 
     execute("DELETE FROM user_ratings WHERE user_id = ?", (user_id,))
     _cached_recommendations.cache_clear()

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -12,6 +12,11 @@ body {
   font-family: Arial, Helvetica, sans-serif;
   transition: opacity .25s ease, transform .25s ease;
 }
+body.auth-modal-open .page-stage {
+  filter: blur(8px);
+  pointer-events: none;
+  user-select: none;
+}
 
 body.page-leave { opacity: .25; transform: translateY(6px); }
 .page-stage { animation: pageEnter .45s ease; min-height: 78vh; }
@@ -517,6 +522,36 @@ body.page-leave { opacity: .25; transform: translateY(6px); }
 .auth-form-card .netflix-input::placeholder {
   color: #5a5a5a;
   opacity: 1;
+}
+
+.guest-auth-modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 3000;
+}
+.guest-auth-modal.show {
+  display: flex;
+}
+.guest-auth-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(2, 4, 12, 0.66);
+  backdrop-filter: blur(3px);
+}
+.guest-auth-card {
+  position: relative;
+  z-index: 1;
+}
+.guest-auth-card .auth-logo {
+  font-size: 2.3rem;
+  text-align: center;
+}
+.guest-auth-card .auth-tagline {
+  text-align: center;
+  margin-bottom: 1rem;
 }
 
 /* modal metadata row consistency */

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,7 +8,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
   <link href="{{ url_for('static', filename='css/style.css') }}" rel="stylesheet">
 </head>
-<body>
+<body data-auth-required="{{ 'true' if is_guest else 'false' }}">
   {% if session.get('user_id') %}
   <nav class="navbar navbar-expand-lg netflix-navbar">
     <div class="container">
@@ -121,6 +121,50 @@
         });
       });
     });
+
+    const authRequired = document.body.dataset.authRequired === 'true';
+    const guestAuthModal = document.getElementById('guestAuthModal');
+
+    const openGuestAuthModal = () => {
+      if (!guestAuthModal) return;
+      guestAuthModal.classList.add('show');
+      guestAuthModal.setAttribute('aria-hidden', 'false');
+      document.body.classList.add('auth-modal-open');
+    };
+
+    guestAuthModal?.querySelectorAll('[data-open-auth-modal]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const nextMode = btn.getAttribute('data-open-auth-modal');
+        const target = nextMode === 'register' ? '{{ url_for("dashboard", auth="register") }}' : '{{ url_for("dashboard", auth="login") }}';
+        window.location.href = target;
+      });
+    });
+
+    if (guestAuthModal && guestAuthModal.classList.contains('show')) {
+      document.body.classList.add('auth-modal-open');
+    }
+
+    guestAuthModal?.querySelectorAll('[data-close-auth-modal]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        guestAuthModal.classList.remove('show');
+        guestAuthModal.setAttribute('aria-hidden', 'true');
+        document.body.classList.remove('auth-modal-open');
+      });
+    });
+
+    if (authRequired) {
+      document.addEventListener('click', (event) => {
+        const target = event.target.closest('a, button, input[type="submit"]');
+        if (!target) return;
+        if (target.closest('#guestAuthModal')) return;
+        if (target.hasAttribute('data-bs-dismiss')) return;
+        if (target.classList.contains('navbar-toggler')) return;
+        const isSafeClick = target.matches('[data-close-auth-modal], .google-btn-placeholder');
+        if (isSafeClick) return;
+        event.preventDefault();
+        openGuestAuthModal();
+      }, true);
+    }
   </script>
 </body>
 </html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -2,12 +2,12 @@
 {% block content %}
 <section class="netflix-hero dashboard-hero">
   <div class="container hero-content-wrap hero-intro-block">
-    <h1>Welcome back, {{ session.get('username', 'Viewer')|title }}</h1>
-    <p>Your movie night dashboard with AI-personalized picks.</p>
+    <h1>{% if is_guest %}Welcome to SmartRecs{% else %}Welcome back, {{ session.get('username', 'Viewer')|title }}{% endif %}</h1>
+    <p>{% if is_guest %}Browse picks instantly. Sign in only when you want to interact.{% else %}Your movie night dashboard with AI-personalized picks.{% endif %}</p>
     <div class="hero-action-buttons">
-      <a href="{{ url_for('rate_movies') }}" class="btn netflix-btn page-shift">Rate Movies</a>
+      <a href="{{ url_for('rate_movies') }}" class="btn netflix-btn page-shift {% if is_guest %}requires-auth{% endif %}" {% if is_guest %}data-requires-auth="true"{% endif %}>Rate Movies</a>
       <form method="post" action="{{ url_for('reset_ratings') }}" class="reset-ratings-form">
-        <button type="submit" class="btn btn-success">Reset</button>
+        <button type="submit" class="btn btn-success {% if is_guest %}requires-auth{% endif %}" {% if is_guest %}data-requires-auth="true"{% endif %}>Reset</button>
       </form>
     </div>
 
@@ -28,13 +28,14 @@
       <div class="movie-info">
         <h5>{{ movie.clean_title }}</h5>
         <p>{{ movie.pretty_genres }}</p>
-        <p class="score-chip">Match {{ '%.2f'|format(movie.score) }}</p>
+        <p class="score-chip">{% if is_guest %}Sign in to unlock match score{% else %}Match {{ '%.2f'|format(movie.score) }}{% endif %}</p>
         <div class="movie-actions">
-          <button class="btn btn-sm netflix-btn" data-bs-toggle="modal" data-bs-target="#movieModal{{ movie.movie_id }}">View Details</button>
+          <button class="btn btn-sm netflix-btn {% if is_guest %}requires-auth{% endif %}" {% if is_guest %}data-requires-auth="true"{% else %}data-bs-toggle="modal" data-bs-target="#movieModal{{ movie.movie_id }}"{% endif %}>View Details</button>
         </div>
       </div>
     </article>
 
+    {% if not is_guest %}
     <div class="modal fade" id="movieModal{{ movie.movie_id }}" tabindex="-1" aria-hidden="true">
       <div class="modal-dialog modal-lg modal-dialog-centered">
         <div class="modal-content netflix-modal">
@@ -65,9 +66,61 @@
         </div>
       </div>
     </div>
+    {% endif %}
     {% endfor %}
   </div>
 </section>
+
+{% if is_guest %}
+<div class="guest-auth-modal {% if auth_mode %}show{% endif %}" id="guestAuthModal" aria-hidden="{% if auth_mode %}false{% else %}true{% endif %}">
+  <div class="guest-auth-backdrop" data-close-auth-modal="true"></div>
+  <div class="guest-auth-card auth-form-card auth-form-card-enter">
+    <h1 class="auth-logo">SmartRecs <span class="popcorn-pop" aria-hidden="true">🍿</span></h1>
+    <p class="auth-tagline">Your next favorite movie is one click away.</p>
+    <h2 class="auth-form-title">{{ 'Register' if auth_mode == 'register' else 'Sign In' }}</h2>
+    {% if auth_mode == 'register' %}
+    <form method="post" action="{{ url_for('register') }}">
+      <div class="mb-3">
+        <label class="form-label">Username</label>
+        <input name="username" class="form-control netflix-input" placeholder="John" required>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Email</label>
+        <input type="email" name="email" class="form-control netflix-input" placeholder="name@email.com">
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Password</label>
+        <input type="password" name="password" class="form-control netflix-input" placeholder="••••••••" required>
+      </div>
+      <button class="btn netflix-btn w-100">Register</button>
+    </form>
+    <div class="auth-switch-copy">
+      <span>Already have an account?</span>
+      <button type="button" class="btn btn-link auth-card-switch" data-open-auth-modal="login">Login</button>
+    </div>
+    {% else %}
+    <form method="post" action="{{ url_for('login') }}">
+      <div class="mb-3">
+        <label class="form-label">Username or Email</label>
+        <input name="identity" class="form-control netflix-input" placeholder="John or name@email.com" required>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Password</label>
+        <input type="password" name="password" class="form-control netflix-input" placeholder="••••••••" required>
+      </div>
+      <button class="btn netflix-btn w-100">Sign In</button>
+    </form>
+    <button type="button" class="btn btn-outline-light w-100 mt-2 google-btn-placeholder">
+      Continue with Google (Firebase)
+    </button>
+    <div class="auth-switch-copy">
+      <span>Don’t have an account?</span>
+      <button type="button" class="btn btn-link auth-card-switch" data-open-auth-modal="register">Register</button>
+    </div>
+    {% endif %}
+  </div>
+</div>
+{% endif %}
 {% endblock %}
 
 {% block footer %}


### PR DESCRIPTION
### Motivation
- Make the actual home/dashboard the first page users see instead of showing the sign-in/register page first.  
- Keep unauthenticated users able to browse, but require sign-in in a floating modal when they attempt protected interactions.  
- Provide a visible placeholder and UI hook for Google sign-in (to be wired to Firebase next). 

### Description
- Routing: changed `/` to always redirect to the dashboard and updated `GET /login` and `GET /register` to redirect back to the dashboard using `?auth=login|register` so auth is shown as a modal instead of a standalone page (`app.py`).  
- Guest-safe dashboard: dashboard now detects guest state (`is_guest`) and shows a starter list of movies with match scores hidden and interactive controls gated by `data-requires-auth`/`requires-auth` attributes (`templates/dashboard.html`, `app.py`).  
- Auth modal UI: added a centered floating auth popup (login/register switch + a `Continue with Google (Firebase)` placeholder button) that can be shown initially via `?auth=` and can be opened by intercepting clicks for guests (`templates/dashboard.html`, `templates/base.html`, `static/css/style.css`).  
- Frontend behavior: added click interception/guard in `templates/base.html` to prevent navigation for guests and open the modal, and added CSS to blur the page while the modal is open (`static/css/style.css`).  
- Protected routes: updated protected endpoints (`/profile`, `/rate`, `/recommendations`, `/reset-ratings`) to redirect guests back to dashboard with a flash message and `?auth=login` so the modal opens instead of navigating away (`app.py`). 

### Testing
- Ran Python byte-compile check with `python -m py_compile app.py` and it completed successfully.  
- Verified the codebase compiles cleanly after the changes (no syntax errors reported by the compile step).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce3de8fe088331b70d979fcb221b11)